### PR TITLE
Update README.md

### DIFF
--- a/releases/R2024a/README.md
+++ b/releases/R2024a/README.md
@@ -23,11 +23,11 @@ Click the **Deploy to Azure** button below to deploy the cloud resources on Azur
 
 | Create Virtual Network | Use Existing Virtual Network |
 | --- | --- |
-| Use this option to deploy the resources in a new virtual network<br><br><a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Freftemplatestorage.blob.core.windows.net%2Fmatlablinux%2F94ce5449-3f73-b98b-e7fe-f1f6cb66be2a%2Fazuredeploy-R2024a-test.json" target="_blank"><img src="https://aka.ms/deploytoazurebutton"/></a></br></br> | Use this option to deploy the resources in an existing virtual network <br><br><a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Freftemplatestorage.blob.core.windows.net%2Fmatlablinux%2F94ce5449-3f73-b98b-e7fe-f1f6cb66be2a%2Fazuredeploy-existing-vnet-R2024a-test.json" target="_blank"><img src="https://aka.ms/deploytoazurebutton"/></a></br></br> |
+| Use this option to deploy the resources in a new virtual network<br><br><a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Freftemplatestorage.blob.core.windows.net%2Fmatlablinux%2F94ce5449-3f73-b98b-e7fe-f1f6cb66be2a%2Fazuredeploy-R2024a.json" target="_blank"><img src="https://aka.ms/deploytoazurebutton"/></a></br></br> | Use this option to deploy the resources in an existing virtual network <br><br><a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Freftemplatestorage.blob.core.windows.net%2Fmatlablinux%2F94ce5449-3f73-b98b-e7fe-f1f6cb66be2a%2Fazuredeploy-existing-vnet-R2024a.json" target="_blank"><img src="https://aka.ms/deploytoazurebutton"/></a></br></br> |
 
 > VM Platform: Ubuntu 22.04
   
-> MATLAB&reg; Release: R2024a-test
+> MATLAB&reg; Release: R2024a
 
 To deploy a custom machine image, see [Deploy Your Own Machine Image](#deploy-your-own-machine-image).
 


### PR DESCRIPTION
Change the 2024a README Azure template link.

@matildaperuzzo and I noticed that the two links under section `1. Launch the Template` pointed to the wrong .json files. Users who are trying to use the standard image shouldn't need to provide a VHD URL, etc.

What you got before the change:

<img width="715" alt="LinuxMATLAB" src="https://github.com/user-attachments/assets/f2ad4130-0437-4bdf-9d4e-966444f7fe7a" />

What you get after:

<img width="703" alt="WindowsMATLAB" src="https://github.com/user-attachments/assets/e0034d54-d985-48d4-9e32-ab8e2fa1f4ad" />
