### PR TITLE
Update Auto-shutdown function app dependencies

### DIFF
--- a/function-apps/mw-autoshutdown-app/run.ps1
+++ b/function-apps/mw-autoshutdown-app/run.ps1
@@ -36,7 +36,7 @@ if ($NumberOfHoursBeforeShutdown -eq 'Never') {
     $NumberOfHoursBeforeShutdown = $TagNeverValue
 }
 
-$VMName = ${env:INSTANCE_NAME}
+$VMName = "matlab-vm"
 
 # Retrieve VM information, contains information about instance tags, instance ID
 $VM = Get-AzVM -Name "$VMName" -ResourceGroupName "$ResourceGroup"

--- a/function-apps/requirements.psd1
+++ b/function-apps/requirements.psd1
@@ -1,10 +1,11 @@
 <#
- This file contains the modules required by the run.ps1 script.
- It enables modules to be automatically managed by the Functions service.
- See https://aka.ms/functionsmanageddependency for additional information.
+This file contains the modules required by the run.ps1 script.
+It enables modules to be automatically managed by the Functions service.
+See https://aka.ms/functionsmanageddependency for additional information.
+Copyright 2023-2025 The MathWorks, Inc.
 #>
 @{
- 'Az.Compute' = '4.*'
- 'Az.Accounts' = '2.*'
- 'Az.Resources' = '5.*'
- }
+    'Az.Compute' = '10.*'
+    'Az.Accounts' = '5.*'
+    'Az.Resources' = '8.*'
+}


### PR DESCRIPTION
Updating the Azure PowerShell modules used in the auto-shutdown function app to a more recent version(s). Currently, versions of the modules used are deprecated making the auto-shutdown function fail during initialization.